### PR TITLE
Change module Go version to go1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/ci.yaml'
   pull_request:
     branches: [ main ]
     paths:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,15 +12,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.23', '1.24', '1.25' ]
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
-          cache: true
-      - name: Install dependencies
-        run: |
-          go get .
-      - name: Run tests
-        run: go test -race -v ./...
+          go-version: ${{ matrix.go-version }}
+      - run: go mod download
+      - run: go vet ./...
+      - uses: dominikh/staticcheck-action@v1
+        with: { install-go: false }
+      - run: go test -v ./...

--- a/context_new_test.go
+++ b/context_new_test.go
@@ -1,0 +1,13 @@
+//go:build go1.24
+
+package unstructured
+
+import (
+	"context"
+	"testing"
+)
+
+// textContext mimics [*testing.T.Context], which was added in go1.24.
+func testContext(t *testing.T) context.Context {
+	return t.Context()
+}

--- a/context_old_test.go
+++ b/context_old_test.go
@@ -1,0 +1,16 @@
+//go:build !go1.24
+
+package unstructured
+
+import (
+	"context"
+	"testing"
+)
+
+// textContext mimics [*testing.T.Context], which was added in go1.24.
+func testContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return ctx
+}

--- a/destination_create_test.go
+++ b/destination_create_test.go
@@ -32,7 +32,7 @@ func TestCreateDestination(t *testing.T) {
 		w.Write(response)
 	}
 
-	destination, err := client.CreateDestination(t.Context(), CreateDestinationRequest{
+	destination, err := client.CreateDestination(testContext(t), CreateDestinationRequest{
 		Name: "test_destination_name",
 
 		Config: &S3ConnectorConfig{

--- a/destination_delete_test.go
+++ b/destination_delete_test.go
@@ -27,7 +27,7 @@ func TestDeleteDestination(t *testing.T) {
 		w.Write(response)
 	}
 
-	err := client.DeleteDestination(t.Context(), "b25d4161-77a0-4e08-b65e-86f398ce15ad")
+	err := client.DeleteDestination(testContext(t), "b25d4161-77a0-4e08-b65e-86f398ce15ad")
 	if err != nil {
 		t.Fatalf("failed to delete destination: %v", err)
 	}

--- a/destination_get_test.go
+++ b/destination_get_test.go
@@ -40,7 +40,7 @@ func TestGetDestination(t *testing.T) {
 		w.Write(response)
 	}
 
-	destination, err := client.GetDestination(t.Context(), id)
+	destination, err := client.GetDestination(testContext(t), id)
 	if err != nil {
 		t.Fatalf("failed to get destination: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestGetDestinationNotFound(t *testing.T) {
 		http.Error(w, "destination ID "+r.PathValue("id")+" not found", http.StatusNotFound)
 	}
 
-	_, err := client.GetDestination(t.Context(), id)
+	_, err := client.GetDestination(testContext(t), id)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}

--- a/destination_list_test.go
+++ b/destination_list_test.go
@@ -37,7 +37,7 @@ func TestListDestinations(t *testing.T) {
 		w.Write(response)
 	}
 
-	destinations, err := client.ListDestinations(t.Context(), "")
+	destinations, err := client.ListDestinations(testContext(t), "")
 	if err != nil {
 		t.Fatalf("failed to list destinations: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestListDestinationsEmpty(t *testing.T) {
 		w.Write([]byte("[]"))
 	}
 
-	destinations, err := client.ListDestinations(t.Context(), "")
+	destinations, err := client.ListDestinations(testContext(t), "")
 	if err != nil {
 		t.Fatalf("failed to list destinations: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestListDestinationsErrorCode(t *testing.T) {
 				w.WriteHeader(code)
 			}
 
-			_, err := client.ListDestinations(t.Context(), "")
+			_, err := client.ListDestinations(testContext(t), "")
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}

--- a/destination_update_test.go
+++ b/destination_update_test.go
@@ -40,7 +40,7 @@ func TestUpdateDestination(t *testing.T) {
 		w.Write(response)
 	}
 
-	updated, err := client.UpdateDestination(t.Context(), UpdateDestinationRequest{
+	updated, err := client.UpdateDestination(testContext(t), UpdateDestinationRequest{
 		ID: id,
 		Config: &S3ConnectorConfig{
 			RemoteURL: "s3://mock-s3-connector",

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/aws-gopher/unstructured-sdk-go
 
-go 1.25.0
+go 1.23

--- a/job_cancel_test.go
+++ b/job_cancel_test.go
@@ -30,7 +30,7 @@ func TestCancelJob(t *testing.T) {
 		w.Write(response)
 	}
 
-	err := client.CancelJob(t.Context(), id)
+	err := client.CancelJob(testContext(t), id)
 	if err != nil {
 		t.Fatalf("failed to cancel job: %v", err)
 	}

--- a/job_get_test.go
+++ b/job_get_test.go
@@ -36,7 +36,7 @@ func TestGetJob(t *testing.T) {
 		w.Write(response)
 	}
 
-	job, err := client.GetJob(t.Context(), id)
+	job, err := client.GetJob(testContext(t), id)
 	if err != nil {
 		t.Fatalf("failed to get job: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestGetJobNotFound(t *testing.T) {
 		http.Error(w, "job ID "+r.PathValue("id")+" not found", http.StatusNotFound)
 	}
 
-	_, err := client.GetJob(t.Context(), id)
+	_, err := client.GetJob(testContext(t), id)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -102,7 +102,7 @@ func TestGetJobError(t *testing.T) {
 				w.WriteHeader(code)
 			}
 
-			_, err := client.GetJob(t.Context(), id)
+			_, err := client.GetJob(testContext(t), id)
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}

--- a/jobs_list_test.go
+++ b/jobs_list_test.go
@@ -30,7 +30,7 @@ func TestListJobs(t *testing.T) {
 		w.Write(response)
 	}
 
-	jobs, err := client.ListJobs(t.Context(), &ListJobsRequest{})
+	jobs, err := client.ListJobs(testContext(t), &ListJobsRequest{})
 	if err != nil {
 		t.Fatalf("failed to list jobs: %v", err)
 	}

--- a/source_create_test.go
+++ b/source_create_test.go
@@ -34,7 +34,7 @@ func TestCreateSource(t *testing.T) {
 		w.Write(response)
 	}
 
-	source, err := client.CreateSource(t.Context(), CreateSourceRequest{
+	source, err := client.CreateSource(testContext(t), CreateSourceRequest{
 		Name: "test_source_name",
 		Config: &OneDriveConnectorConfig{
 			ClientID:     "foo",

--- a/source_delete_test.go
+++ b/source_delete_test.go
@@ -27,7 +27,7 @@ func TestDeleteSource(t *testing.T) {
 		w.Write(response)
 	}
 
-	err := client.DeleteSource(t.Context(), id)
+	err := client.DeleteSource(testContext(t), id)
 	if err != nil {
 		t.Fatalf("failed to delete source: %v", err)
 	}

--- a/source_get_test.go
+++ b/source_get_test.go
@@ -41,7 +41,7 @@ func TestGetSource(t *testing.T) {
 		w.Write(response)
 	}
 
-	source, err := client.GetSource(t.Context(), id)
+	source, err := client.GetSource(testContext(t), id)
 	if err != nil {
 		t.Fatalf("failed to get source: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestGetSourceNotFound(t *testing.T) {
 		http.Error(w, "source ID "+r.PathValue("id")+" not found", http.StatusNotFound)
 	}
 
-	_, err := client.GetSource(t.Context(), id)
+	_, err := client.GetSource(testContext(t), id)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}

--- a/source_list_test.go
+++ b/source_list_test.go
@@ -38,7 +38,7 @@ func TestListSources(t *testing.T) {
 		w.Write(response)
 	}
 
-	sources, err := client.ListSources(t.Context(), "")
+	sources, err := client.ListSources(testContext(t), "")
 	if err != nil {
 		t.Fatalf("failed to list sources: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestListSourcesEmpty(t *testing.T) {
 		w.Write(response)
 	}
 
-	sources, err := client.ListSources(t.Context(), "")
+	sources, err := client.ListSources(testContext(t), "")
 	if err != nil {
 		t.Fatalf("failed to list sources: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestListSourcesErrorCode(t *testing.T) {
 				w.WriteHeader(code)
 			}
 
-			_, err := client.ListSources(t.Context(), "")
+			_, err := client.ListSources(testContext(t), "")
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}

--- a/source_update_test.go
+++ b/source_update_test.go
@@ -43,7 +43,7 @@ func TestUpdateSource(t *testing.T) {
 		w.Write(response)
 	}
 
-	source, err := client.UpdateSource(t.Context(), UpdateSourceRequest{
+	source, err := client.UpdateSource(testContext(t), UpdateSourceRequest{
 		ID: id,
 		Config: &OneDriveConnectorConfig{
 			ClientID:     "foo",

--- a/test/destination_test.go
+++ b/test/destination_test.go
@@ -200,7 +200,7 @@ func TestDestinationPermutations(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			destination, err := client.CreateDestination(t.Context(), unstructured.CreateDestinationRequest{
+			destination, err := client.CreateDestination(testContext(t), unstructured.CreateDestinationRequest{
 				Name:   fmt.Sprintf("test-%s-%s", name, rand.Text()),
 				Config: src,
 			})

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -41,7 +41,7 @@ func TestWorkflow(t *testing.T) {
 		t.Fatalf("failed to create client: %v", err)
 	}
 
-	ctx := t.Context()
+	ctx := testContext(t)
 
 	workflow, err := client.CreateWorkflow(ctx, &unstructured.CreateWorkflowRequest{
 		Name: "test",

--- a/test/source_test.go
+++ b/test/source_test.go
@@ -186,7 +186,7 @@ func TestSourcePermutations(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			source, err := client.CreateSource(t.Context(), unstructured.CreateSourceRequest{
+			source, err := client.CreateSource(testContext(t), unstructured.CreateSourceRequest{
 				Name:   fmt.Sprintf("test-%s-%s", name, rand.Text()),
 				Config: src,
 			})

--- a/workflow_create_test.go
+++ b/workflow_create_test.go
@@ -30,7 +30,7 @@ func TestCreateWorkflow(t *testing.T) {
 		w.Write(response)
 	}
 
-	workflow, err := client.CreateWorkflow(t.Context(), &CreateWorkflowRequest{
+	workflow, err := client.CreateWorkflow(testContext(t), &CreateWorkflowRequest{
 		Name:          "test_workflow",
 		Schedule:      String("weekly"),
 		SourceID:      String("f1f7b1b2-8e4b-4a2b-8f1d-3e3c7c9e5a3c"),

--- a/workflow_list_test.go
+++ b/workflow_list_test.go
@@ -34,7 +34,7 @@ func TestListWorkflows(t *testing.T) {
 		w.Write(response)
 	}
 
-	workflows, err := client.ListWorkflows(t.Context(), &ListWorkflowsRequest{
+	workflows, err := client.ListWorkflows(testContext(t), &ListWorkflowsRequest{
 		SortBy: String("id"),
 	})
 	if err != nil {
@@ -73,7 +73,7 @@ func TestListWorkflowsEmpty(t *testing.T) {
 		w.Write(response)
 	}
 
-	workflows, err := client.ListWorkflows(t.Context(), &ListWorkflowsRequest{
+	workflows, err := client.ListWorkflows(testContext(t), &ListWorkflowsRequest{
 		SortBy: String("id"),
 	})
 	if err != nil {
@@ -108,7 +108,7 @@ func TestListWorkflowsErrorCode(t *testing.T) {
 				w.WriteHeader(code)
 			}
 
-			_, err := client.ListWorkflows(t.Context(), &ListWorkflowsRequest{
+			_, err := client.ListWorkflows(testContext(t), &ListWorkflowsRequest{
 				SortBy: String("id"),
 			})
 			if err == nil {

--- a/workflow_run_test.go
+++ b/workflow_run_test.go
@@ -33,7 +33,7 @@ func TestRunWorkflow(t *testing.T) {
 		w.Write(response)
 	}
 
-	job, err := client.RunWorkflow(t.Context(), &RunWorkflowRequest{ID: id})
+	job, err := client.RunWorkflow(testContext(t), &RunWorkflowRequest{ID: id})
 	if err != nil {
 		t.Fatalf("failed to run workflow: %v", err)
 	}

--- a/workflow_update_test.go
+++ b/workflow_update_test.go
@@ -33,7 +33,7 @@ func TestUpdateWorkflow(t *testing.T) {
 		w.Write(response)
 	}
 
-	updated, err := client.UpdateWorkflow(t.Context(), UpdateWorkflowRequest{
+	updated, err := client.UpdateWorkflow(testContext(t), UpdateWorkflowRequest{
 		ID:            id,
 		Name:          String("test_workflow"),
 		WorkflowType:  Ptr(WorkflowTypeAdvanced),


### PR DESCRIPTION
Update tests for go1.23    

- Extract `func testContext(t *testing.T) context.Context` with two different implementations. g1.24 and above will continue to use `(*testing.T).Context` as before, while go1.23 gets a hand-rolled approximation.
- Update all callsites of `(*testing.T).Context` to use `testContext` instead.
- Once the module Go version is updated to go1.24 or later, this change can be reversed.

CI Changes:
- Use matrix strategy to test go1.23, go1.24, go1.25  
- Adds `go vet` for linting
- Adds `staticcheck` for static analysis
- Only trigger CI on PR events