### PR TITLE
CI integration test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,4 +24,7 @@ jobs:
       - run: go vet ./...
       - uses: dominikh/staticcheck-action@v1
         with: { install-go: false }
-      - run: go test -v ./...
+      - run: go test -v .
+      - run: go test -v -tags integration ./test
+        env:
+          UNSTRUCTURED_API_KEY: ${{ secrets.UNSTRUCTURED_API_KEY }}

--- a/test/context_new_test.go
+++ b/test/context_new_test.go
@@ -1,0 +1,18 @@
+//go:build go1.24 && integration
+
+package test
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+)
+
+// textContext mimics [*testing.T.Context], which was added in go1.24.
+func testContext(t *testing.T) context.Context {
+	return t.Context()
+}
+
+func randText() string {
+	return rand.Text()
+}

--- a/test/context_old_test.go
+++ b/test/context_old_test.go
@@ -1,0 +1,27 @@
+//go:build !go1.24 && integration
+
+package test
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+)
+
+// textContext mimics [*testing.T.Context], which was added in go1.24.
+func testContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func randText() string {
+	const base32 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+	src := make([]byte, 26)
+	rand.Read(src)
+	for i := range src {
+		src[i] = base32[src[i]%32]
+	}
+	return string(src)
+}

--- a/test/destination_test.go
+++ b/test/destination_test.go
@@ -4,7 +4,6 @@ package test
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
 	"os"
 	"testing"
@@ -201,7 +200,7 @@ func TestDestinationPermutations(t *testing.T) {
 			t.Parallel()
 
 			destination, err := client.CreateDestination(testContext(t), unstructured.CreateDestinationRequest{
-				Name:   fmt.Sprintf("test-%s-%s", name, rand.Text()),
+				Name:   fmt.Sprintf("test-%s-%s", name, randText()),
 				Config: src,
 			})
 			if err != nil {

--- a/test/source_test.go
+++ b/test/source_test.go
@@ -4,7 +4,6 @@ package test
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
 	"os"
 	"testing"
@@ -187,7 +186,7 @@ func TestSourcePermutations(t *testing.T) {
 			t.Parallel()
 
 			source, err := client.CreateSource(testContext(t), unstructured.CreateSourceRequest{
-				Name:   fmt.Sprintf("test-%s-%s", name, rand.Text()),
+				Name:   fmt.Sprintf("test-%s-%s", name, randText()),
 				Config: src,
 			})
 			if err != nil {


### PR DESCRIPTION
Run integration test with API key after local tests.
Update integration test for go1.23

- Add `testContext(*testing.T) context.Context` in `./test` package, with version-specific implementations matching `package unstructured`
- Add `randText() string` in `./test` package. Version-specific implmentation for go1.24 and later delegates to `crypto/rand.Text`, while the implementation for go1.23 simply copies the body of `crypto/rand.Text` into a local implementation.
